### PR TITLE
Allow filtering on natural keys

### DIFF
--- a/Event/Subscriber/DoctrineORMSubscriber.php
+++ b/Event/Subscriber/DoctrineORMSubscriber.php
@@ -108,7 +108,7 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
                     $expr->eq($filterField, ':'.$paramName),
                     array($paramName => array(
                         $this->getEntityIdentifier($values['value'], $queryBuilder->getEntityManager()),
-                        Type::INTEGER
+                        $this->getEntityIdentifierType($values['value'], $queryBuilder->getEntityManager()),
                     ))
                 );
             }
@@ -136,5 +136,24 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
         }
 
         return array_shift($identifierValues);
+    }
+    
+    /**
+     * @param object $value
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function getEntityIdentifierType($value, EntityManagerInterface $em)
+    {
+        $class = get_class($value);
+        $metadata = $em->getClassMetadata($class);
+
+        $identifierType = $metadata->getIdentifierFieldNames($value);
+
+        if (empty($identifierType)) {
+            throw new \RuntimeException(sprintf('Can\'t get identifier value for class "%s".', $class));
+        }
+
+        return $metadata->getTypeOfField(array_shift($identifierType));
     }
 }


### PR DESCRIPTION
## Why?
The bundle assumes that relations are surrogate keys, and they are always of `Type::INTEGER`.

## What?
This change uses class metadata to get the correct type for the identifier.

## Notes
This is the result of a morning's debugging, working out why specific filters weren't working. It is submitted for discussion and to see if there's a better approach. It's not yet suitable to merge as there are no tests written.